### PR TITLE
Update billiard to 4.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,10 @@ build:
 
 requirements:
   build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler("c") }}
+    - {{ stdlib("c") }}
   host:
     - python
     - wheel
@@ -31,7 +34,7 @@ test:
     - billiard
     - billiard.compat
     - billiard.connection
-    - billiard.dummmy
+    - billiard.dummy
     - billiard.pool
     - billiard.process
     - billiard.queues
@@ -56,6 +59,7 @@ about:
     This standalone variant draws its fixes/improvements from python-trunk
     and provides additional bug fixes and improvements.
   dev_url: https://github.com/celery/billiard
+  doc_ur: https://billiard.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler("c") }}
     - {{ stdlib("c") }}
   host:
@@ -60,7 +58,7 @@ about:
     This standalone variant draws its fixes/improvements from python-trunk
     and provides additional bug fixes and improvements.
   dev_url: https://github.com/celery/billiard
-  doc_ur: https://billiard.readthedocs.io
+  doc_url: https://billiard.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ stdlib("c") }}
   host:
     - python
+    - setuptools
     - wheel
     - pip
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,49 @@
-{% set version = "3.6.4.0" %}
+{% set name = "billiard" %}
+{% set version = "4.2.1" %}
 
 package:
-  name: billiard
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/b/billiard/billiard-{{ version }}.tar.gz
-  sha256: 299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 12b641b0c539073fc8d3f5b8b7be998956665c4233c7c1fcd66a7e677c4fb36f
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: true # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ compiler("c") }}
   host:
     - python
+    - wheel
     - pip
   run:
     - python
 
 test:
+  source_files:
+    - t
   imports:
     - billiard
-    - billiard.dummy
+    - billiard.compat
+    - billiard.connection
+    - billiard.dummmy
+    - billiard.pool
+    - billiard.process
+    - billiard.queues
+  requires:
+    - pip
+    - pytest >=6.2
+    - psutil >=5.9.0
+  commands:
+    - pip check
+    - pytest -vv t/unit
+    # Integration tests are out-dated (last changes adaa178 2 years ago) and broken
+    # - pytest -vv t/integration
 
 about:
   home: https://github.com/celery/billiard
@@ -32,6 +51,10 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Python multiprocessing fork with improvements and bugfixes
+  description: |
+    billiard is a fork of the Python 2.7 multiprocessing package.
+    This standalone variant draws its fixes/improvements from python-trunk
+    and provides additional bug fixes and improvements.
   dev_url: https://github.com/celery/billiard
 
 extra:


### PR DESCRIPTION
billiard 4.2.1 

**Destination channel:** Default

### Links

- [PKG-9095](https://anaconda.atlassian.net/browse/PKG-9095)
- dev_url:        https://github.com/celery/billiard/tree/v4.2.1
- conda_forge:    https://github.com/conda-forge/billiard-feedstock
- pypi:           https://pypi.org/project/billiard/4.2.1
- pypi inspector: https://inspector.pypi.io/project/billiard/4.2.1

### Explanation of changes:

- new version number


[PKG-9095]: https://anaconda.atlassian.net/browse/PKG-9095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ